### PR TITLE
Normalize MAC address to lower case using prepareConfig

### DIFF
--- a/dash-button.coffee
+++ b/dash-button.coffee
@@ -28,6 +28,7 @@ module.exports = (env) =>
       deviceConfigDef = require('./device-config-schema.coffee')
 
       @framework.deviceManager.registerDeviceClass 'DashButtonDevice',
+        prepareConfig: DashButtonDevice.prepareConfig
         configDef: deviceConfigDef.DashButtonDevice
         createCallback: (config, lastState) =>
           return new DashButtonDevice(config, pcapSession)
@@ -69,6 +70,9 @@ module.exports = (env) =>
 
     _listener: null
 
+    @prepareConfig: (config) =>
+      config.address = config.address.toLowerCase() if config.address?
+  
     constructor: (@config, @pcapSession) ->
       @id = @config.id
       @name = @config.name

--- a/dash-button.coffee
+++ b/dash-button.coffee
@@ -71,7 +71,11 @@ module.exports = (env) =>
     _listener: null
 
     @prepareConfig: (config) =>
-      config.address = config.address.toLowerCase() if config.address?
+      address = (config.address || '').replace /\W/g, ''
+      if address.length is 12
+        config.address = address.replace(/(.{2})/g, '$1:').toLowerCase().slice(0, -1)
+      else
+        env.logger.error "Invalid MAC address: #{config.address || 'Property "address" missing'}"
   
     constructor: (@config, @pcapSession) ->
       @id = @config.id


### PR DESCRIPTION
This will automatically normalize the MAC address to lower case before the device is instantiated. This way, user can also provide the MAC address using upper case letters.

See also https://forum.pimatic.org/topic/2327/pimatic-dash-button-problem
